### PR TITLE
fix: enforce dark color scheme

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -17,6 +17,10 @@ body {
   font-size: 12px;
 }
 
+html {
+  color-scheme: dark;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);
@@ -47,12 +51,6 @@ header {
   display: flex;
   flex-direction: column;
   align-items: center;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- set the global html color scheme to dark to avoid rendering the /video scrollbars with a light track

## Testing
- not run (node_modules missing locally)

Fixes #26